### PR TITLE
Fix radius CPU bug

### DIFF
--- a/torch_cluster/radius.py
+++ b/torch_cluster/radius.py
@@ -95,6 +95,8 @@ def radius(x: torch.Tensor, y: torch.Tensor, r: float,
         col = [torch.tensor(c, dtype=torch.long) for c in col]
         col = [sample(c, max_num_neighbors) for c in col]
         row = [torch.full_like(c, i) for i, c in enumerate(col)]
+        row = [r for r in row if r.size(0) != 0]
+        col = [c for c in col if c.size(0) != 0]
         row, col = torch.cat(row, dim=0), torch.cat(col, dim=0)
         mask = col < int(tree.n)
         return torch.stack([row[mask], col[mask]], dim=0)


### PR DESCRIPTION
In the CPU version of the radius function, when no points in input tensor `x` are within a distance `r` of a point in tensor `y` an empty tensor is inserted into both the row and col lists. When concatenating the tensors in those lists, this results in an error (try code below).
```
import torch
import torch_geometric.nn as tgnn

query_pts = torch.tensor([[0., 0.], [1., 1.], [0., 0.], [1., 1.]])
pts = torch.tensor([[1., 1.],])
edges = tgnn.radius(pts, query_pts, 0.2)
```

The fix just removes all of the empty tensors in both lists. They line up (i.e. `row[i] = tensor([])` if and only if `col[i] = tensor([])`, so running through them both separately shouldn't result in any discrepancies. Removing them in an earlier step (i.e. line 95) results in a shift in the resulting indices.

GPU version works as expected.