### PR TITLE
improve infererence the number of nodes

### DIFF
--- a/torch_cluster/rw.py
+++ b/torch_cluster/rw.py
@@ -32,7 +32,7 @@ def random_walk(row: Tensor, col: Tensor, start: Tensor, walk_length: int,
     :rtype: :class:`LongTensor`
     """
     if num_nodes is None:
-        num_nodes = max(int(row.max()), int(col.max())) + 1
+        num_nodes = max(int(row.max()), int(col.max()), int(start.max())) + 1
 
     if coalesced:
         perm = torch.argsort(row * num_nodes + col)


### PR DESCRIPTION
Hi, @rusty1s 

As you suggested it in https://github.com/rusty1s/pytorch_cluster/issues/111, I modified the inference of the number of nodes in `random_walk`. I verified that even if I did not specify `num_nodes`, there was no segmentation faults.