### PR TITLE
Enable returning distances from knn and knn_graph

### DIFF
--- a/csrc/cpu/knn_cpu.h
+++ b/csrc/cpu/knn_cpu.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <tuple>
+
 #include "../extensions.h"
 
-torch::Tensor knn_cpu(torch::Tensor x, torch::Tensor y,
-                      torch::optional<torch::Tensor> ptr_x,
-                      torch::optional<torch::Tensor> ptr_y, int64_t k,
-                      int64_t num_workers);
+std::tuple<torch::Tensor, torch::Tensor>
+knn_cpu(torch::Tensor x, torch::Tensor y,
+        torch::optional<torch::Tensor> ptr_x,
+        torch::optional<torch::Tensor> ptr_y, int64_t k,
+        int64_t num_workers);

--- a/csrc/cuda/knn_cuda.h
+++ b/csrc/cuda/knn_cuda.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <tuple>
+
 #include "../extensions.h"
 
-torch::Tensor knn_cuda(torch::Tensor x, torch::Tensor y,
-                       torch::optional<torch::Tensor> ptr_x,
-                       torch::optional<torch::Tensor> ptr_y, int64_t k,
-                       bool cosine);
+std::tuple<torch::Tensor, torch::Tensor>
+knn_cuda(torch::Tensor x, torch::Tensor y,
+         torch::optional<torch::Tensor> ptr_x,
+         torch::optional<torch::Tensor> ptr_y, int64_t k,
+         bool cosine);

--- a/csrc/knn.cpp
+++ b/csrc/knn.cpp
@@ -15,10 +15,11 @@ PyMODINIT_FUNC PyInit__knn_cpu(void) { return NULL; }
 #endif
 #endif
 
-CLUSTER_API torch::Tensor knn(torch::Tensor x, torch::Tensor y,
-                  torch::optional<torch::Tensor> ptr_x,
-                  torch::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
-                  int64_t num_workers) {
+CLUSTER_API std::tuple<torch::Tensor, torch::Tensor> knn(
+    torch::Tensor x, torch::Tensor y,
+    torch::optional<torch::Tensor> ptr_x,
+    torch::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
+    int64_t num_workers) {
   if (x.device().is_cuda()) {
 #ifdef WITH_CUDA
     return knn_cuda(x, y, ptr_x, ptr_y, k, cosine);

--- a/test/test_knn.py
+++ b/test/test_knn.py
@@ -35,11 +35,14 @@ def test_knn(dtype, device):
 
     edge_index, distances = knn(x, y, 2, return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 0), (1, 1)])
-    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
-    edge_index, distances = knn(x, y, 2, batch_x, batch_y, return_distances=True)
+    edge_index, distances = knn(x, y, 2, batch_x, batch_y,
+                                return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
-    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
     if x.is_cuda:
         edge_index, distances = knn(
@@ -53,16 +56,18 @@ def test_knn(dtype, device):
     # Skipping a batch
     batch_x = tensor([0, 0, 0, 0, 2, 2, 2, 2], torch.long, device)
     batch_y = tensor([0, 2], torch.long, device)
-    edge_index,distances = knn(x, y, 2, batch_x, batch_y, return_distances=True)
+    edge_index, distances = knn(x, y, 2, batch_x, batch_y,
+                                return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
-    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
 
 @pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
 def test_knn_jit(dtype, device):
     @torch.jit.script
-    def knn_jit(x: torch.Tensor, y: torch.Tensor, k: int, batch_x: torch.Tensor,
-                batch_y: torch.Tensor):
+    def knn_jit(x: torch.Tensor, y: torch.Tensor, k: int,
+                batch_x: torch.Tensor, batch_y: torch.Tensor):
         return knn(x, y, k, batch_x, batch_y)
 
     @torch.jit.script
@@ -93,7 +98,8 @@ def test_knn_jit(dtype, device):
 
     edge_index, distances = knn_jit_distance(x, y, 2, batch_x, batch_y)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
-    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
 
 @pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
@@ -110,7 +116,8 @@ def test_knn_graph(dtype, device):
     )
     assert to_set(edge_index) == set([(0, 1), (0, 3), (1, 0), (1, 2), (2, 1),
                                       (2, 3), (3, 0), (3, 2)])
-    assert torch.allclose(distances, distances.new_tensor([4.0 for _ in range(8)]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([4.0 for _ in range(8)]))
 
     edge_index = knn_graph(
         x, k=2, flow='source_to_target', return_distances=False
@@ -143,7 +150,8 @@ def test_knn_graph_jit(dtype, device):
     edge_index, distances = knn_graph_jit_distance(x, k=2)
     assert to_set(edge_index) == set([(0, 1), (0, 3), (1, 0), (1, 2), (2, 1),
                                       (2, 3), (3, 0), (3, 2)])
-    assert torch.allclose(distances, distances.new_tensor([4.0 for _ in range(8)]))
+    assert torch.allclose(distances,
+                          distances.new_tensor([4.0 for _ in range(8)]))
 
 
 @pytest.mark.parametrize('dtype,device', product([torch.float], devices))

--- a/test/test_knn.py
+++ b/test/test_knn.py
@@ -1,3 +1,4 @@
+import math
 from itertools import product
 
 import pytest
@@ -32,21 +33,67 @@ def test_knn(dtype, device):
     batch_x = tensor([0, 0, 0, 0, 1, 1, 1, 1], torch.long, device)
     batch_y = tensor([0, 1], torch.long, device)
 
-    edge_index = knn(x, y, 2)
+    edge_index, distances = knn(x, y, 2, return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 0), (1, 1)])
+    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
-    edge_index = knn(x, y, 2, batch_x, batch_y)
+    edge_index, distances = knn(x, y, 2, batch_x, batch_y, return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
+    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
     if x.is_cuda:
-        edge_index = knn(x, y, 2, batch_x, batch_y, cosine=True)
+        edge_index, distances = knn(
+            x, y, 2, batch_x, batch_y, cosine=True, return_distances=True
+        )
         assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
+        assert torch.allclose(distances, distances.new_tensor(
+            [1.0 - math.cos(math.pi / 4.0) for _ in range(4)]
+        ))
 
     # Skipping a batch
     batch_x = tensor([0, 0, 0, 0, 2, 2, 2, 2], torch.long, device)
     batch_y = tensor([0, 2], torch.long, device)
-    edge_index = knn(x, y, 2, batch_x, batch_y)
+    edge_index,distances = knn(x, y, 2, batch_x, batch_y, return_distances=True)
     assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
+    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
+
+
+@pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
+def test_knn_jit(dtype, device):
+    @torch.jit.script
+    def knn_jit(x: torch.Tensor, y: torch.Tensor, k: int, batch_x: torch.Tensor,
+                batch_y: torch.Tensor):
+        return knn(x, y, k, batch_x, batch_y)
+
+    @torch.jit.script
+    def knn_jit_distance(x: torch.Tensor, y: torch.Tensor, k: int,
+                         batch_x: torch.Tensor, batch_y: torch.Tensor):
+        return knn(x, y, k, batch_x, batch_y, return_distances=True)
+
+    x = tensor([
+        [-1, -1],
+        [-1, +1],
+        [+1, +1],
+        [+1, -1],
+        [-1, -1],
+        [-1, +1],
+        [+1, +1],
+        [+1, -1],
+    ], dtype, device)
+    y = tensor([
+        [1, 0],
+        [-1, 0],
+    ], dtype, device)
+
+    batch_x = tensor([0, 0, 0, 0, 1, 1, 1, 1], torch.long, device)
+    batch_y = tensor([0, 1], torch.long, device)
+
+    edge_index = knn_jit(x, y, 2, batch_x, batch_y)
+    assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
+
+    edge_index, distances = knn_jit_distance(x, y, 2, batch_x, batch_y)
+    assert to_set(edge_index) == set([(0, 2), (0, 3), (1, 4), (1, 5)])
+    assert torch.allclose(distances, distances.new_tensor([1.0, 1.0, 1.0, 1.0]))
 
 
 @pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
@@ -58,23 +105,60 @@ def test_knn_graph(dtype, device):
         [+1, -1],
     ], dtype, device)
 
-    edge_index = knn_graph(x, k=2, flow='target_to_source')
+    edge_index, distances = knn_graph(
+        x, k=2, flow='target_to_source', return_distances=True
+    )
+    assert to_set(edge_index) == set([(0, 1), (0, 3), (1, 0), (1, 2), (2, 1),
+                                      (2, 3), (3, 0), (3, 2)])
+    assert torch.allclose(distances, distances.new_tensor([4.0 for _ in range(8)]))
+
+    edge_index = knn_graph(
+        x, k=2, flow='source_to_target', return_distances=False
+    )
+    assert to_set(edge_index) == set([(1, 0), (3, 0), (0, 1), (2, 1), (1, 2),
+                                      (3, 2), (0, 3), (2, 3)])
+
+
+@pytest.mark.parametrize('dtype,device', product(grad_dtypes, devices))
+def test_knn_graph_jit(dtype, device):
+    @torch.jit.script
+    def knn_graph_jit(x: torch.Tensor, k: int):
+        return knn_graph(x, k, flow="target_to_source")
+
+    @torch.jit.script
+    def knn_graph_jit_distance(x: torch.Tensor, k: int):
+        return knn_graph(x, k, flow="target_to_source", return_distances=True)
+
+    x = tensor([
+        [-1, -1],
+        [-1, +1],
+        [+1, +1],
+        [+1, -1],
+    ], dtype, device)
+
+    edge_index = knn_graph_jit(x, k=2)
     assert to_set(edge_index) == set([(0, 1), (0, 3), (1, 0), (1, 2), (2, 1),
                                       (2, 3), (3, 0), (3, 2)])
 
-    edge_index = knn_graph(x, k=2, flow='source_to_target')
-    assert to_set(edge_index) == set([(1, 0), (3, 0), (0, 1), (2, 1), (1, 2),
-                                      (3, 2), (0, 3), (2, 3)])
+    edge_index, distances = knn_graph_jit_distance(x, k=2)
+    assert to_set(edge_index) == set([(0, 1), (0, 3), (1, 0), (1, 2), (2, 1),
+                                      (2, 3), (3, 0), (3, 2)])
+    assert torch.allclose(distances, distances.new_tensor([4.0 for _ in range(8)]))
 
 
 @pytest.mark.parametrize('dtype,device', product([torch.float], devices))
 def test_knn_graph_large(dtype, device):
     x = torch.randn(1000, 3, dtype=dtype, device=device)
 
-    edge_index = knn_graph(x, k=5, flow='target_to_source', loop=True)
+    edge_index, distances = knn_graph(
+        x, k=5, flow='target_to_source', loop=True, return_distances=True
+    )
 
     tree = scipy.spatial.cKDTree(x.cpu().numpy())
-    _, col = tree.query(x.cpu(), k=5)
+    dist, col = tree.query(x.cpu(), k=5)
     truth = set([(i, j) for i, ns in enumerate(col) for j in ns])
 
     assert to_set(edge_index.cpu()) == truth
+    assert torch.allclose(
+        distances, torch.from_numpy(dist).to(distances).flatten().pow(2)
+    )

--- a/torch_cluster/knn.py
+++ b/torch_cluster/knn.py
@@ -94,7 +94,7 @@ def _knn_return_output(
     cosine: bool = False,
     num_workers: int = 1,
     return_distances: bool = False
-) -> torch.Tensor:
+) -> torch.Tensor: # pragma: no cover
     output, _ = _knn_impl(x, y, k, batch_x, batch_y, cosine,
                           num_workers, return_distances)
 

--- a/torch_cluster/knn.py
+++ b/torch_cluster/knn.py
@@ -94,7 +94,7 @@ def _knn_return_output(
     cosine: bool = False,
     num_workers: int = 1,
     return_distances: bool = False
-) -> torch.Tensor: # pragma: no cover
+) -> torch.Tensor:  # pragma: no cover
     output, _ = _knn_impl(x, y, k, batch_x, batch_y, cosine,
                           num_workers, return_distances)
 

--- a/torch_cluster/knn.py
+++ b/torch_cluster/knn.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -95,8 +95,8 @@ def _knn_return_output(
     num_workers: int = 1,
     return_distances: bool = False
 ) -> torch.Tensor:
-    output, _ =  _knn_impl(x, y, k, batch_x, batch_y, cosine, num_workers,
-        return_distances)
+    output, _ = _knn_impl(x, y, k, batch_x, batch_y, cosine,
+                          num_workers, return_distances)
 
     return output
 
@@ -168,7 +168,7 @@ def _knn_graph_impl(
 
     assert flow in ['source_to_target', 'target_to_source']
     edge_index, distances = knn(x, x, k if loop else k + 1, batch, batch,
-        cosine, num_workers, return_distances=True)
+                                cosine, num_workers, return_distances=True)
 
     if flow == 'source_to_target':
         row, col = edge_index[1], edge_index[0]
@@ -196,7 +196,7 @@ def _knn_graph_return_output(
     return_distances: bool = False,
 ) -> torch.Tensor:
     output, _ = _knn_graph_impl(x, k, batch, loop, flow, cosine, num_workers,
-        return_distances)
+                                return_distances)
 
     return output
 


### PR DESCRIPTION
**TL;DR** Add a switch for `knn` and `knn_graph` to enable returning distances alongside the edge_index.

This code has been tested on CPU and CUDA 11.3 with PyTorch 1.11.0 on Ubuntu 18.04.

Related: pyg-team/pytorch_geometric#3010

------

I still cannot directly decorate `knn` and `knn_graph` with `@torch.jit.script` per your suggestions (https://github.com/pyg-team/pytorch_geometric/issues/3010#issuecomment-1166582712). So I took a slightly different approach which was similar to https://github.com/pytorch/pytorch/issues/37986. Though `@torch.jit.script` has to be removed from the above two functions, the code that uses those two functions can be correctly jitted. Is it OK with you? @rusty1s 

