### PR TITLE
Fix for preventing absolute paths from appearing in egg-info's SOURCES listing file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,4 @@ setup(
         BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=False)
     },
     packages=find_packages(),
-    include_package_data=True,
 )


### PR DESCRIPTION
According to both my own personal experience while using this and other packages as well as the general consensus of this post - https://stackoverflow.com/questions/18085571/pip-install-error-setup-script-specifies-an-absolute-path - the following line should be removed the setup script in order to make sure that no improper absolute paths appear in the manifest of a build distribution:
https://github.com/rusty1s/pytorch_cluster/blob/master/setup.py#L128

My commit addresses this here:
https://github.com/PierceLBrooks/pytorch_cluster/commit/efa71ec0f7743e5fac3f64a09df5ce913adb5936

As an additional note, the other geometric pytorch_* packages do not themselves define this flag in their setup scripts either, so this change will also establish better parity with them.