### PR TITLE
Extended compilation instructions C++ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,13 +282,13 @@ pytest
 ## C++ API
 
 `torch-cluster` also offers a C++ API that contains C++ equivalent of python models.
-For this, we need to add `TorchLib` to the `-DCMAKE_PREFIX_PATH` (*e.g.*, it may exists in `{CONDA}/lib/python{X.X}/site-packages/torch` if installed via `conda`):
 
 ```
+export Torch_DIR=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
 mkdir build
 cd build
 # Add -DWITH_CUDA=on support for the CUDA if needed
-cmake -DCMAKE_PREFIX_PATH="..." ..
+cmake ..
 make
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ pytest
 ## C++ API
 
 `torch-cluster` also offers a C++ API that contains C++ equivalent of python models.
+For this, we need to add `TorchLib` to the `-DCMAKE_PREFIX_PATH` (*e.g.*, it may exists in `{CONDA}/lib/python{X.X}/site-packages/torch` if installed via `conda`):
 
 ```
 mkdir build

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ pytest
 mkdir build
 cd build
 # Add -DWITH_CUDA=on support for the CUDA if needed
-cmake ..
+cmake -DCMAKE_PREFIX_PATH="..." ..
 make
 make install
 ```


### PR DESCRIPTION
In analogy to https://github.com/rusty1s/pytorch_scatter and https://github.com/rusty1s/pytorch_sparse, `-DCMAKE_PREFIX_PATH` needs to be set to the path `libtorch` lives (at least I couldn't compile otherwise).

I copied instructions from your other repos.