### PR TITLE
fix(packaging): pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR resolves #204

This change declares `torch` as a build dependency for this package since it's used in the `setup.py` - see [setuptools build system support](https://setuptools.pypa.io/en/latest/build_meta.html#build-system-support). 

Here is the new `pyproject.toml` file:

```toml
[build-system]
requires = ["setuptools", "torch"]
build-backend = "setuptools.build_meta"
```

Once this is done `pip` will understand that `torch` is a build dependency and this package can be installed from PyPI and an `ImportError` will no longer be raised. When you `pip install pytorch-cluster` the package will now build itself from source as part of its installation process.

## Testing

The below command uses the Python Package Authority's [build](https://github.com/pypa/build) package to test the fix. I was able to build wheels for x86 and ARM (M2) MacOS after this change (using Rosetta for x86):

```shell
pip install build
python -m build
> ...
> Successfully built torch_cluster-1.6.3.tar.gz and torch_cluster-1.6.3-cp311-cp311-macosx_13_0_arm64.whl
```