### PR TITLE
Add num_points to fps as an alternative to ratio

### DIFF
--- a/csrc/cluster.h
+++ b/csrc/cluster.h
@@ -11,7 +11,7 @@ CLUSTER_INLINE_VARIABLE int64_t _cuda_version = cuda_version();
 } // namespace cluster
 
 CLUSTER_API torch::Tensor fps(torch::Tensor src, torch::Tensor ptr, double ratio,
-                  bool random_start);
+                  int64_t num_points, bool random_start);
 
 CLUSTER_API torch::Tensor graclus(torch::Tensor rowptr, torch::Tensor col,
                       torch::optional<torch::Tensor> optional_weight);

--- a/csrc/cpu/fps_cpu.h
+++ b/csrc/cpu/fps_cpu.h
@@ -3,4 +3,4 @@
 #include "../extensions.h"
 
 torch::Tensor fps_cpu(torch::Tensor src, torch::Tensor ptr, torch::Tensor ratio,
-                      bool random_start);
+                      torch::Tensor num_points, bool random_start);

--- a/csrc/cuda/fps_cuda.h
+++ b/csrc/cuda/fps_cuda.h
@@ -3,4 +3,5 @@
 #include "../extensions.h"
 
 torch::Tensor fps_cuda(torch::Tensor src, torch::Tensor ptr,
-                       torch::Tensor ratio, bool random_start);
+                       torch::Tensor ratio, torch::Tensor num_points,
+                       bool random_start);

--- a/csrc/fps.cpp
+++ b/csrc/fps.cpp
@@ -19,16 +19,17 @@ PyMODINIT_FUNC PyInit__fps_cpu(void) { return NULL; }
 #endif
 #endif
 
-CLUSTER_API torch::Tensor fps(torch::Tensor src, torch::Tensor ptr, torch::Tensor ratio,
-                  bool random_start) {
+CLUSTER_API torch::Tensor fps(torch::Tensor src, torch::Tensor ptr,
+                              torch::Tensor ratio, torch::Tensor num_points,
+                              bool random_start) {
   if (src.device().is_cuda()) {
 #ifdef WITH_CUDA
-    return fps_cuda(src, ptr, ratio, random_start);
+    return fps_cuda(src, ptr, ratio, num_points, random_start);
 #else
     AT_ERROR("Not compiled with CUDA support");
 #endif
   } else {
-    return fps_cpu(src, ptr, ratio, random_start);
+    return fps_cpu(src, ptr, ratio, num_points, random_start);
   }
 }
 

--- a/torch_cluster/fps.py
+++ b/torch_cluster/fps.py
@@ -7,26 +7,49 @@ import torch_cluster.typing
 
 
 @torch.jit._overload  # noqa
-def fps(src, batch, ratio, random_start, batch_size, ptr):  # noqa
-    # type: (Tensor, Optional[Tensor], Optional[float], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[float], Optional[int], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
     pass  # pragma: no cover
 
 
 @torch.jit._overload  # noqa
-def fps(src, batch, ratio, random_start, batch_size, ptr):  # noqa
-    # type: (Tensor, Optional[Tensor], Optional[Tensor], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[int], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
     pass  # pragma: no cover
 
 
 @torch.jit._overload  # noqa
-def fps(src, batch, ratio, random_start, batch_size, ptr):  # noqa
-    # type: (Tensor, Optional[Tensor], Optional[float], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[float], Optional[int], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
     pass  # pragma: no cover
 
 
 @torch.jit._overload  # noqa
-def fps(src, batch, ratio, random_start, batch_size, ptr):  # noqa
-    # type: (Tensor, Optional[Tensor], Optional[Tensor], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[int], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
+    pass  # pragma: no cover
+
+@torch.jit._overload  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[float], Optional[Tensor], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
+    pass  # pragma: no cover
+
+
+@torch.jit._overload  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor], bool, Optional[int], Optional[Tensor]) -> Tensor  # noqa
+    pass  # pragma: no cover
+
+
+@torch.jit._overload  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[float], Optional[Tensor], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
+    pass  # pragma: no cover
+
+
+@torch.jit._overload  # noqa
+def fps(src, batch, ratio, num_points, random_start, batch_size, ptr):  # noqa
+    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor], bool, Optional[int], Optional[List[int]]) -> Tensor  # noqa
     pass  # pragma: no cover
 
 
@@ -34,6 +57,7 @@ def fps(  # noqa
     src: torch.Tensor,
     batch: Optional[Tensor] = None,
     ratio: Optional[Union[Tensor, float]] = None,
+    num_points: Optional[Union[Tensor, int]] = None,
     random_start: bool = True,
     batch_size: Optional[int] = None,
     ptr: Optional[Union[Tensor, List[int]]] = None,
@@ -50,7 +74,11 @@ def fps(  # noqa
             :math:`\mathbf{b} \in {\{ 0, \ldots, B-1\}}^N`, which assigns each
             node to a specific example. (default: :obj:`None`)
         ratio (float or Tensor, optional): Sampling ratio.
+            Only ratio or num_points can be specified.
             (default: :obj:`0.5`)
+        num_points (int, optional): Number of returned points.
+            Only ratio or num_points can be specified.
+            (default: :obj:`None`)
         random_start (bool, optional): If set to :obj:`False`, use the first
             node in :math:`\mathbf{X}` as starting node. (default: obj:`True`)
         batch_size (int, optional): The number of examples :math:`B`.
@@ -71,25 +99,47 @@ def fps(  # noqa
         batch = torch.tensor([0, 0, 0, 0])
         index = fps(src, batch, ratio=0.5)
     """
+    # check if only of of ratio or num_points is set
+    # if no one is set, fallback to ratio = 0.5
+    if ratio is not None and num_points is not None:
+        raise ValueError("Only one of ratio and num_points can be specified.")
+
     r: Optional[Tensor] = None
     if ratio is None:
-        r = torch.tensor(0.5, dtype=src.dtype, device=src.device)
+        if num_points is None:
+            r = torch.tensor(0.5, dtype=src.dtype, device=src.device)
+        else:
+            r = torch.tensor(0.0, dtype=src.dtype, device=src.device)
     elif isinstance(ratio, float):
         r = torch.tensor(ratio, dtype=src.dtype, device=src.device)
     else:
         r = ratio
-    assert r is not None
+
+    num: Optional[Tensor] = None
+    if num_points is None:
+        num = torch.tensor(0, dtype=torch.long, device=src.device)
+    elif isinstance(num_points, int):
+        num = torch.tensor(num_points, dtype=torch.long, device=src.device)
+    else:
+        num = num_points
+
+    assert r is not None and num is not None
+
+    if r.sum() == 0 and num.sum() == 0:
+        raise ValueError("At least one of ratio or num_points should be > 0")
 
     if ptr is not None:
         if isinstance(ptr, list) and torch_cluster.typing.WITH_PTR_LIST:
             return torch.ops.torch_cluster.fps_ptr_list(
-                src, ptr, r, random_start)
+                src, ptr, r, random_start
+            )
 
         if isinstance(ptr, list):
             return torch.ops.torch_cluster.fps(
-                src, torch.tensor(ptr, device=src.device), r, random_start)
+                src, torch.tensor(ptr, device=src.device), r, num, random_start
+            )
         else:
-            return torch.ops.torch_cluster.fps(src, ptr, r, random_start)
+            return torch.ops.torch_cluster.fps(src, ptr, r, num, random_start)
 
     if batch is not None:
         assert src.size(0) == batch.numel()
@@ -104,4 +154,4 @@ def fps(  # noqa
     else:
         ptr_vec = torch.tensor([0, src.size(0)], device=src.device)
 
-    return torch.ops.torch_cluster.fps(src, ptr_vec, r, random_start)
+    return torch.ops.torch_cluster.fps(src, ptr_vec, r, num, random_start)


### PR DESCRIPTION
The current implementation of farthest point sampling only allows to set a ratio value to define the number of output points. Some use-cases require a fixed number of output points. 

This PR adds an argument `num_points` to allow this. I also added some tests. The implementation raises a runtime exception if the number of requested points is greater than the number of input points.