### PR TITLE
Fix the number of neighbors bug in `radius_graph`

### DIFF
--- a/csrc/cpu/radius_cpu.h
+++ b/csrc/cpu/radius_cpu.h
@@ -5,4 +5,5 @@
 torch::Tensor radius_cpu(torch::Tensor x, torch::Tensor y,
                          torch::optional<torch::Tensor> ptr_x,
                          torch::optional<torch::Tensor> ptr_y, double r,
-                         int64_t max_num_neighbors, int64_t num_workers);
+                         int64_t max_num_neighbors, int64_t num_workers,
+                         bool ignore_same_index);

--- a/csrc/cuda/radius_cuda.h
+++ b/csrc/cuda/radius_cuda.h
@@ -5,4 +5,5 @@
 torch::Tensor radius_cuda(torch::Tensor x, torch::Tensor y,
                           torch::optional<torch::Tensor> ptr_x,
                           torch::optional<torch::Tensor> ptr_y, double r,
-                          int64_t max_num_neighbors);
+                          int64_t max_num_neighbors,
+                          bool ignore_same_index);

--- a/csrc/radius.cpp
+++ b/csrc/radius.cpp
@@ -22,15 +22,16 @@ PyMODINIT_FUNC PyInit__radius_cpu(void) { return NULL; }
 CLUSTER_API torch::Tensor radius(torch::Tensor x, torch::Tensor y,
                      torch::optional<torch::Tensor> ptr_x,
                      torch::optional<torch::Tensor> ptr_y, double r,
-                     int64_t max_num_neighbors, int64_t num_workers) {
+                     int64_t max_num_neighbors, int64_t num_workers,
+                     bool ignore_same_index) {
   if (x.device().is_cuda()) {
 #ifdef WITH_CUDA
-    return radius_cuda(x, y, ptr_x, ptr_y, r, max_num_neighbors);
+    return radius_cuda(x, y, ptr_x, ptr_y, r, max_num_neighbors, ignore_same_index);
 #else
     AT_ERROR("Not compiled with CUDA support");
 #endif
   } else {
-    return radius_cpu(x, y, ptr_x, ptr_y, r, max_num_neighbors, num_workers);
+    return radius_cpu(x, y, ptr_x, ptr_y, r, max_num_neighbors, num_workers, ignore_same_index);
   }
 }
 

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -10,6 +10,12 @@ from torch_cluster.testing import devices, floating_dtypes, tensor
 def to_set(edge_index):
     return set([(i, j) for i, j in edge_index.t().tolist()])
 
+def to_degree(edge_index):
+    _, counts = torch.unique(edge_index[1], return_counts=True)
+    return counts.tolist()
+
+def to_batch(nodes):
+    return [int(i / 4) for i in nodes]
 
 @pytest.mark.parametrize('dtype,device', product(floating_dtypes, devices))
 def test_radius(dtype, device):
@@ -73,7 +79,35 @@ def test_radius_graph(dtype, device):
     edge_index = jit(x, r=2.5, flow='source_to_target')
     assert to_set(edge_index) == set([(1, 0), (3, 0), (0, 1), (2, 1), (1, 2),
                                       (3, 2), (0, 3), (2, 3)])
+    
+    edge_index = radius_graph(x, r=100, flow='source_to_target', max_num_neighbors=1)
+    assert set(to_degree(edge_index)) == set([1])
 
+    x = tensor([
+        [-1, -1],
+        [-1, -1],
+        [-1, -1],
+        [-1, -1],
+    ], dtype, device)
+
+    edge_index = radius_graph(x, r=100, flow='source_to_target', max_num_neighbors=1)
+    assert set(to_degree(edge_index)) == set([1])
+
+    x = tensor([
+        [-1, -1],
+        [-1, +1],
+        [+1, +1],
+        [+1, -1],
+        [-1, -1],
+        [-1, +1],
+        [+1, +1],
+        [+1, -1],
+    ], dtype, device)
+    batch_x = tensor([0, 0, 0, 0, 1, 1, 1, 1], torch.long, device)
+
+    edge_index = radius_graph(x, r=100, batch=batch_x, flow='source_to_target', max_num_neighbors=1)
+    assert set(to_degree(edge_index)) == set([1])
+    assert to_batch(edge_index[0]) == batch_x.tolist()
 
 @pytest.mark.parametrize('dtype,device', product([torch.float], devices))
 def test_radius_graph_large(dtype, device):

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -10,12 +10,15 @@ from torch_cluster.testing import devices, floating_dtypes, tensor
 def to_set(edge_index):
     return set([(i, j) for i, j in edge_index.t().tolist()])
 
+
 def to_degree(edge_index):
     _, counts = torch.unique(edge_index[1], return_counts=True)
     return counts.tolist()
 
+
 def to_batch(nodes):
     return [int(i / 4) for i in nodes]
+
 
 @pytest.mark.parametrize('dtype,device', product(floating_dtypes, devices))
 def test_radius(dtype, device):
@@ -79,8 +82,9 @@ def test_radius_graph(dtype, device):
     edge_index = jit(x, r=2.5, flow='source_to_target')
     assert to_set(edge_index) == set([(1, 0), (3, 0), (0, 1), (2, 1), (1, 2),
                                       (3, 2), (0, 3), (2, 3)])
-    
-    edge_index = radius_graph(x, r=100, flow='source_to_target', max_num_neighbors=1)
+
+    edge_index = radius_graph(x, r=100, flow='source_to_target',
+                              max_num_neighbors=1)
     assert set(to_degree(edge_index)) == set([1])
 
     x = tensor([
@@ -90,7 +94,8 @@ def test_radius_graph(dtype, device):
         [-1, -1],
     ], dtype, device)
 
-    edge_index = radius_graph(x, r=100, flow='source_to_target', max_num_neighbors=1)
+    edge_index = radius_graph(x, r=100, flow='source_to_target',
+                              max_num_neighbors=1)
     assert set(to_degree(edge_index)) == set([1])
 
     x = tensor([
@@ -105,9 +110,11 @@ def test_radius_graph(dtype, device):
     ], dtype, device)
     batch_x = tensor([0, 0, 0, 0, 1, 1, 1, 1], torch.long, device)
 
-    edge_index = radius_graph(x, r=100, batch=batch_x, flow='source_to_target', max_num_neighbors=1)
+    edge_index = radius_graph(x, r=100, batch=batch_x, flow='source_to_target',
+                              max_num_neighbors=1)
     assert set(to_degree(edge_index)) == set([1])
     assert to_batch(edge_index[0]) == batch_x.tolist()
+
 
 @pytest.mark.parametrize('dtype,device', product([torch.float], devices))
 def test_radius_graph_large(dtype, device):


### PR DESCRIPTION
This change fixes the bug in Issue #219 .
An optional parameter `ignore_same_index` is added to the end of the parameters list of `radius`, so that it doesn't break existing codes.
Unit tests are added to test for the bug in non-batched mode and batched mode, and when there are coincident points.