### PR TITLE
c10::optional -> std::optional

### DIFF
--- a/csrc/cluster.h
+++ b/csrc/cluster.h
@@ -14,15 +14,15 @@ CLUSTER_API torch::Tensor fps(torch::Tensor src, torch::Tensor ptr, torch::Tenso
                   bool random_start);
 
 CLUSTER_API torch::Tensor graclus(torch::Tensor rowptr, torch::Tensor col,
-                      torch::optional<torch::Tensor> optional_weight);
+                      std::optional<torch::Tensor> optional_weight);
 
 CLUSTER_API torch::Tensor grid(torch::Tensor pos, torch::Tensor size,
-                   torch::optional<torch::Tensor> optional_start,
-                   torch::optional<torch::Tensor> optional_end);
+                   std::optional<torch::Tensor> optional_start,
+                   std::optional<torch::Tensor> optional_end);
 
 CLUSTER_API torch::Tensor knn(torch::Tensor x, torch::Tensor y,
-                  torch::optional<torch::Tensor> ptr_x,
-                  torch::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
+                  std::optional<torch::Tensor> ptr_x,
+                  std::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
                   int64_t num_workers);
 
 CLUSTER_API torch::Tensor nearest(torch::Tensor x, torch::Tensor y, torch::Tensor ptr_x,

--- a/csrc/cpu/graclus_cpu.cpp
+++ b/csrc/cpu/graclus_cpu.cpp
@@ -3,7 +3,7 @@
 #include "utils.h"
 
 torch::Tensor graclus_cpu(torch::Tensor rowptr, torch::Tensor col,
-                          torch::optional<torch::Tensor> optional_weight) {
+                          std::optional<torch::Tensor> optional_weight) {
   CHECK_CPU(rowptr);
   CHECK_CPU(col);
   CHECK_INPUT(rowptr.dim() == 1 && col.dim() == 1);

--- a/csrc/cpu/graclus_cpu.h
+++ b/csrc/cpu/graclus_cpu.h
@@ -3,4 +3,4 @@
 #include "../extensions.h"
 
 torch::Tensor graclus_cpu(torch::Tensor rowptr, torch::Tensor col,
-                          torch::optional<torch::Tensor> optional_weight);
+                          std::optional<torch::Tensor> optional_weight);

--- a/csrc/cpu/grid_cpu.cpp
+++ b/csrc/cpu/grid_cpu.cpp
@@ -3,8 +3,8 @@
 #include "utils.h"
 
 torch::Tensor grid_cpu(torch::Tensor pos, torch::Tensor size,
-                       torch::optional<torch::Tensor> optional_start,
-                       torch::optional<torch::Tensor> optional_end) {
+                       std::optional<torch::Tensor> optional_start,
+                       std::optional<torch::Tensor> optional_end) {
 
   CHECK_CPU(pos);
   CHECK_CPU(size);

--- a/csrc/cpu/grid_cpu.h
+++ b/csrc/cpu/grid_cpu.h
@@ -2,5 +2,5 @@
 
 #include "../extensions.h"
 torch::Tensor grid_cpu(torch::Tensor pos, torch::Tensor size,
-                       torch::optional<torch::Tensor> optional_start,
-                       torch::optional<torch::Tensor> optional_end);
+                       std::optional<torch::Tensor> optional_start,
+                       std::optional<torch::Tensor> optional_end);

--- a/csrc/cpu/knn_cpu.cpp
+++ b/csrc/cpu/knn_cpu.cpp
@@ -5,8 +5,8 @@
 #include "utils/nanoflann.hpp"
 
 torch::Tensor knn_cpu(torch::Tensor x, torch::Tensor y,
-                      torch::optional<torch::Tensor> ptr_x,
-                      torch::optional<torch::Tensor> ptr_y, int64_t k,
+                      std::optional<torch::Tensor> ptr_x,
+                      std::optional<torch::Tensor> ptr_y, int64_t k,
                       int64_t num_workers) {
 
   CHECK_CPU(x);

--- a/csrc/cpu/knn_cpu.h
+++ b/csrc/cpu/knn_cpu.h
@@ -3,6 +3,6 @@
 #include "../extensions.h"
 
 torch::Tensor knn_cpu(torch::Tensor x, torch::Tensor y,
-                      torch::optional<torch::Tensor> ptr_x,
-                      torch::optional<torch::Tensor> ptr_y, int64_t k,
+                      std::optional<torch::Tensor> ptr_x,
+                      std::optional<torch::Tensor> ptr_y, int64_t k,
                       int64_t num_workers);

--- a/csrc/cpu/radius_cpu.cpp
+++ b/csrc/cpu/radius_cpu.cpp
@@ -5,8 +5,8 @@
 #include "utils/nanoflann.hpp"
 
 torch::Tensor radius_cpu(torch::Tensor x, torch::Tensor y,
-                         torch::optional<torch::Tensor> ptr_x,
-                         torch::optional<torch::Tensor> ptr_y, double r,
+                         std::optional<torch::Tensor> ptr_x,
+                         std::optional<torch::Tensor> ptr_y, double r,
                          int64_t max_num_neighbors, int64_t num_workers,
                          bool ignore_same_index) {
 

--- a/csrc/cpu/radius_cpu.h
+++ b/csrc/cpu/radius_cpu.h
@@ -3,7 +3,7 @@
 #include "../extensions.h"
 
 torch::Tensor radius_cpu(torch::Tensor x, torch::Tensor y,
-                         torch::optional<torch::Tensor> ptr_x,
-                         torch::optional<torch::Tensor> ptr_y, double r,
+                         std::optional<torch::Tensor> ptr_x,
+                         std::optional<torch::Tensor> ptr_y, double r,
                          int64_t max_num_neighbors, int64_t num_workers,
                          bool ignore_same_index);

--- a/csrc/cuda/graclus_cuda.cu
+++ b/csrc/cuda/graclus_cuda.cu
@@ -103,7 +103,7 @@ __global__ void weighted_propose_kernel(int64_t *out, int64_t *proposal,
 
 void propose(torch::Tensor out, torch::Tensor proposal, torch::Tensor rowptr,
              torch::Tensor col,
-             torch::optional<torch::Tensor> optional_weight) {
+             std::optional<torch::Tensor> optional_weight) {
 
   auto stream = at::cuda::getCurrentCUDAStream();
 
@@ -192,7 +192,7 @@ __global__ void weighted_respond_kernel(int64_t *out, const int64_t *proposal,
 
 void respond(torch::Tensor out, torch::Tensor proposal, torch::Tensor rowptr,
              torch::Tensor col,
-             torch::optional<torch::Tensor> optional_weight) {
+             std::optional<torch::Tensor> optional_weight) {
 
   auto stream = at::cuda::getCurrentCUDAStream();
 
@@ -214,7 +214,7 @@ void respond(torch::Tensor out, torch::Tensor proposal, torch::Tensor rowptr,
 }
 
 torch::Tensor graclus_cuda(torch::Tensor rowptr, torch::Tensor col,
-                           torch::optional<torch::Tensor> optional_weight) {
+                           std::optional<torch::Tensor> optional_weight) {
   CHECK_CUDA(rowptr);
   CHECK_CUDA(col);
   CHECK_INPUT(rowptr.dim() == 1 && col.dim() == 1);

--- a/csrc/cuda/graclus_cuda.h
+++ b/csrc/cuda/graclus_cuda.h
@@ -3,4 +3,4 @@
 #include "../extensions.h"
 
 torch::Tensor graclus_cuda(torch::Tensor rowptr, torch::Tensor col,
-                           torch::optional<torch::Tensor> optional_weight);
+                           std::optional<torch::Tensor> optional_weight);

--- a/csrc/cuda/grid_cuda.cu
+++ b/csrc/cuda/grid_cuda.cu
@@ -25,8 +25,8 @@ __global__ void grid_kernel(const scalar_t *pos, const scalar_t *size,
 }
 
 torch::Tensor grid_cuda(torch::Tensor pos, torch::Tensor size,
-                        torch::optional<torch::Tensor> optional_start,
-                        torch::optional<torch::Tensor> optional_end) {
+                        std::optional<torch::Tensor> optional_start,
+                        std::optional<torch::Tensor> optional_end) {
   CHECK_CUDA(pos);
   CHECK_CUDA(size);
   c10::cuda::MaybeSetDevice(pos.get_device());

--- a/csrc/cuda/grid_cuda.h
+++ b/csrc/cuda/grid_cuda.h
@@ -3,5 +3,5 @@
 #include "../extensions.h"
 
 torch::Tensor grid_cuda(torch::Tensor pos, torch::Tensor size,
-                        torch::optional<torch::Tensor> optional_start,
-                        torch::optional<torch::Tensor> optional_end);
+                        std::optional<torch::Tensor> optional_start,
+                        std::optional<torch::Tensor> optional_end);

--- a/csrc/cuda/knn_cuda.cu
+++ b/csrc/cuda/knn_cuda.cu
@@ -84,8 +84,8 @@ knn_kernel(const scalar_t *__restrict__ x, const scalar_t *__restrict__ y,
 }
 
 torch::Tensor knn_cuda(const torch::Tensor x, const torch::Tensor y,
-                       torch::optional<torch::Tensor> ptr_x,
-                       torch::optional<torch::Tensor> ptr_y, const int64_t k,
+                       std::optional<torch::Tensor> ptr_x,
+                       std::optional<torch::Tensor> ptr_y, const int64_t k,
                        const bool cosine) {
 
   CHECK_CUDA(x);

--- a/csrc/cuda/knn_cuda.h
+++ b/csrc/cuda/knn_cuda.h
@@ -3,6 +3,6 @@
 #include "../extensions.h"
 
 torch::Tensor knn_cuda(torch::Tensor x, torch::Tensor y,
-                       torch::optional<torch::Tensor> ptr_x,
-                       torch::optional<torch::Tensor> ptr_y, int64_t k,
+                       std::optional<torch::Tensor> ptr_x,
+                       std::optional<torch::Tensor> ptr_y, int64_t k,
                        bool cosine);

--- a/csrc/cuda/radius_cuda.cu
+++ b/csrc/cuda/radius_cuda.cu
@@ -42,8 +42,8 @@ radius_kernel(const scalar_t *__restrict__ x, const scalar_t *__restrict__ y,
 }
 
 torch::Tensor radius_cuda(const torch::Tensor x, const torch::Tensor y,
-                          torch::optional<torch::Tensor> ptr_x,
-                          torch::optional<torch::Tensor> ptr_y, const double r,
+                          std::optional<torch::Tensor> ptr_x,
+                          std::optional<torch::Tensor> ptr_y, const double r,
                           const int64_t max_num_neighbors,
                           const bool ignore_same_index) {
   CHECK_CUDA(x);

--- a/csrc/cuda/radius_cuda.h
+++ b/csrc/cuda/radius_cuda.h
@@ -3,7 +3,7 @@
 #include "../extensions.h"
 
 torch::Tensor radius_cuda(torch::Tensor x, torch::Tensor y,
-                          torch::optional<torch::Tensor> ptr_x,
-                          torch::optional<torch::Tensor> ptr_y, double r,
+                          std::optional<torch::Tensor> ptr_x,
+                          std::optional<torch::Tensor> ptr_y, double r,
                           int64_t max_num_neighbors,
                           bool ignore_same_index);

--- a/csrc/graclus.cpp
+++ b/csrc/graclus.cpp
@@ -20,7 +20,7 @@ PyMODINIT_FUNC PyInit__graclus_cpu(void) { return NULL; }
 #endif
 
 CLUSTER_API torch::Tensor graclus(torch::Tensor rowptr, torch::Tensor col,
-                      torch::optional<torch::Tensor> optional_weight) {
+                      std::optional<torch::Tensor> optional_weight) {
   if (rowptr.device().is_cuda()) {
 #ifdef WITH_CUDA
     return graclus_cuda(rowptr, col, optional_weight);

--- a/csrc/grid.cpp
+++ b/csrc/grid.cpp
@@ -20,8 +20,8 @@ PyMODINIT_FUNC PyInit__grid_cpu(void) { return NULL; }
 #endif
 
 CLUSTER_API torch::Tensor grid(torch::Tensor pos, torch::Tensor size,
-                   torch::optional<torch::Tensor> optional_start,
-                   torch::optional<torch::Tensor> optional_end) {
+                   std::optional<torch::Tensor> optional_start,
+                   std::optional<torch::Tensor> optional_end) {
   if (pos.device().is_cuda()) {
 #ifdef WITH_CUDA
     return grid_cuda(pos, size, optional_start, optional_end);

--- a/csrc/knn.cpp
+++ b/csrc/knn.cpp
@@ -20,8 +20,8 @@ PyMODINIT_FUNC PyInit__knn_cpu(void) { return NULL; }
 #endif
 
 CLUSTER_API torch::Tensor knn(torch::Tensor x, torch::Tensor y,
-                  torch::optional<torch::Tensor> ptr_x,
-                  torch::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
+                  std::optional<torch::Tensor> ptr_x,
+                  std::optional<torch::Tensor> ptr_y, int64_t k, bool cosine,
                   int64_t num_workers) {
   if (x.device().is_cuda()) {
 #ifdef WITH_CUDA

--- a/csrc/radius.cpp
+++ b/csrc/radius.cpp
@@ -20,8 +20,8 @@ PyMODINIT_FUNC PyInit__radius_cpu(void) { return NULL; }
 #endif
 
 CLUSTER_API torch::Tensor radius(torch::Tensor x, torch::Tensor y,
-                     torch::optional<torch::Tensor> ptr_x,
-                     torch::optional<torch::Tensor> ptr_y, double r,
+                     std::optional<torch::Tensor> ptr_x,
+                     std::optional<torch::Tensor> ptr_y, double r,
                      int64_t max_num_neighbors, int64_t num_workers,
                      bool ignore_same_index) {
   if (x.device().is_cuda()) {


### PR DESCRIPTION
Since Nov 29, 2023, PyTorch's `c10::optional` has been an alias for `std::optional` ([link](https://github.com/pytorch/pytorch/commit/165f4f6ccf7522d75df99c30821d583dfc58ad62)).

As of Dec 17, 2024, PyTorch  has begun taking steps to begin removing the `c10::optional` alias entirely ([link](https://github.com/pytorch/pytorch/commit/e2d47a133b928c1b11ae970ced760810bcd4bda4)). The old API remains available, for now, but you can check whether your code has eliminated all instances of deprecated APIs by compiling with `C10_NODEPRECATED` defined as a preprocessor flag (`-DC10_NODEPRECATED`).

This PR converts your existing usages of `c10::optional` to `std::optional` (same for `nullopt`).

(Additional deprecated APIs include `C10_UNUSED`, `C10_NODISCARD`, and `c10::string_view`.)