### PR TITLE
Set CMAKE_CXX_STANDARD to 17 to be compatible with torch > 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(torchcluster)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(TORCHCLUSTER_VERSION 1.6.3)
 
 option(WITH_CUDA "Enable CUDA support" OFF)


### PR DESCRIPTION
This change is required to be able to build a PyTorch cluster with torch > 2.0.  See https://github.com/rusty1s/pytorch_cluster/issues/229