### PR TITLE
Implement error check for negative edge weights in Graclus

### DIFF
--- a/torch_cluster/graclus.py
+++ b/torch_cluster/graclus.py
@@ -51,6 +51,9 @@ def graclus_cluster(
     row, col = row[perm], col[perm]
 
     if weight is not None:
+        if (weight < 0).any().item():
+            raise ValueError(f"PyG's implementation of Graclus clustering "
+                            f"does not support negative edge weights.")
         weight = weight[perm]
 
     deg = row.new_zeros(num_nodes)

--- a/torch_cluster/graclus.py
+++ b/torch_cluster/graclus.py
@@ -40,8 +40,8 @@ def graclus_cluster(
 
     if weight is not None:
         if (weight < 0).any().item():
-            raise ValueError(f"PyG's implementation of Graclus clustering "
-                             f"does not support negative edge weights.")
+            raise ValueError("PyG's implementation of Graclus clustering "
+                             "does not support negative edge weights.")
         weight = weight[mask]
 
     # Randomly shuffle nodes.

--- a/torch_cluster/graclus.py
+++ b/torch_cluster/graclus.py
@@ -39,6 +39,9 @@ def graclus_cluster(
     row, col = row[mask], col[mask]
 
     if weight is not None:
+        if (weight < 0).any().item():
+            raise ValueError(f"PyG's implementation of Graclus clustering "
+                             f"does not support negative edge weights.")
         weight = weight[mask]
 
     # Randomly shuffle nodes.
@@ -51,9 +54,6 @@ def graclus_cluster(
     row, col = row[perm], col[perm]
 
     if weight is not None:
-        if (weight < 0).any().item():
-            raise ValueError(f"PyG's implementation of Graclus clustering "
-                            f"does not support negative edge weights.")
         weight = weight[perm]
 
     deg = row.new_zeros(num_nodes)


### PR DESCRIPTION
Negative edge weights interfere with Graclus clustering and can cause an indefinite hang when executed on CUDA. This adds a small check to validate the edge weights supplied as input are positive.

An alternative would be to tweak the CUDA implementation to safely handle negative weights, but the effectiveness of the algorithm would still be spotty as negative edge weights can prevent merges and result in many singleton clusters.

#fixes https://github.com/pyg-team/pytorch_geometric/issues/10548